### PR TITLE
Add wrapped SDL2 dependency to tsdl

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     },
     "version": "0.9.1",
     "dependencies": {
+        "sdl2": "https://github.com/bsansouci/sdl2.git",
         "@opam-alpha/topkg": "*",
         "@opam-alpha/ctypes-foreign": "*",
         "@opam-alpha/ocamlfind": "*",


### PR DESCRIPTION
I'm not 100% sure this PR makes any sense... Do I need to modify the npm version of this package?

This SDL2 wrapper will download a version of SDL2, unzip it and make it. It will then add to `PKG_CONFIG_PATH` to point to that local sdl2 :D